### PR TITLE
Remove deprecated `.json`

### DIFF
--- a/flask_jsonschema.py
+++ b/flask_jsonschema.py
@@ -56,7 +56,7 @@ class JsonSchema(object):
             @wraps(fn)
             def decorated(*args, **kwargs):
                 schema = current_app.extensions['jsonschema'].get_schema(path)
-                validate(request.json, schema)
+                validate(request.get_json(), schema)
                 return fn(*args, **kwargs)
             return decorated
         return wrapper

--- a/tests.py
+++ b/tests.py
@@ -43,6 +43,15 @@ class JsonSchemaTests(unittest.TestCase):
         r = client.post(
             '/books',
             content_type='application/json',
+            data="Not valid JSON because ends with comma,",
+        )
+
+        self.assertEqual(r.status_code, 400)
+
+    def test_json_does_not_conform_to_schema(self):
+        r = client.post(
+            '/books',
+            content_type='application/json',
             data=json.dumps({
                 'title': 'Infinite Jest'
             })


### PR DESCRIPTION
Fixes #11 

This adds a test to confirm that behaviour remains the same (the test passes with the old implementation) and does not change as per https://github.com/mattupstate/flask-jsonschema/issues/3.
